### PR TITLE
Fixing suggested pbkdf2 cost/iterations

### DIFF
--- a/client-development.md
+++ b/client-development.md
@@ -57,7 +57,7 @@ You send this token via an HTTP header:
 
 ### Registration
 
-On registration, the client will choose a cost for PBKDF2. Recommended is 60,000 for native platforms and 3,000 for web platforms.
+On registration, the client will choose a cost for PBKDF2. Recommended is at least 100,000 for native platforms and 3,000 for web platforms.
 
 To register, the client must also generate a salt. For logging in, the salt is returned by the server, but for registering, it must be done locally.
 

--- a/standard-file.md
+++ b/standard-file.md
@@ -281,7 +281,7 @@ Note: client-server connections must be made securely through SSL/TLS.
 
 | name | details |
 | --- | --- |
-| pw_cost | The number of iterations to be used by the KDF. On native platforms, this should be around 100,000. However note that non-native clients (web clients not using WebCrypto) will not be able to handle any more than 3,000 iterations. |
+| pw_cost | The number of iterations to be used by the KDF. On native platforms, this should be at least 100,000. However note that non-native clients (web clients not using WebCrypto) will not be able to handle any more than 3,000 iterations. |
 | pw_salt | A salt for password derivation. This value is initially created by the client during registration. |
 
 <h1><a id='key-generation'></a>Key Generation</h1>


### PR DESCRIPTION
* Fixed inconsistency in docs - 100,000 vs 60,000
* The [Python docs](https://docs.python.org/3/library/hashlib.html#hashlib.pbkdf2_hmac) recommend at least 100,000 iterations