### PR TITLE
fix link markup

### DIFF
--- a/extensions/publishing.md
+++ b/extensions/publishing.md
@@ -26,7 +26,7 @@ metatype: json
 }
 ```
 
-1. Head over to [listed.standardnotes.org]([https://listed.standardnotes.org](https://listed.standardnotes.org), and generate an account by clicking "Generate Author Link". Copy that link, then, in the Extensions menu in Standard Notes, click "Import Extension" in the bottom right corner. Paste in your link, and press enter, then accept.
+1. Head over to [listed.standardnotes.org](https://listed.standardnotes.org), and generate an account by clicking "Generate Author Link". Copy that link, then, in the Extensions menu in Standard Notes, click "Import Extension" in the bottom right corner. Paste in your link, and press enter, then accept.
 
 2. Back in your "my-extension.json" note, click "Actions" in the menu bar below the note title, then click "Publish to Private Link". Click "Open Private Link" to preview your JSON endpoint.
 

--- a/extensions/publishing.md
+++ b/extensions/publishing.md
@@ -26,7 +26,7 @@ metatype: json
 }
 ```
 
-1. Head over to \[listed.standardnotes.org\]\([https://listed.standardnotes.org\](https://listed.standardnotes.org%29\), and generate an account by clicking "Generate Author Link". Copy that link, then, in the Extensions menu in Standard Notes, click "Import Extension" in the bottom right corner. Paste in your link, and press enter, then accept.
+1. Head over to [listed.standardnotes.org]([https://listed.standardnotes.org](https://listed.standardnotes.org), and generate an account by clicking "Generate Author Link". Copy that link, then, in the Extensions menu in Standard Notes, click "Import Extension" in the bottom right corner. Paste in your link, and press enter, then accept.
 
 2. Back in your "my-extension.json" note, click "Actions" in the menu bar below the note title, then click "Publish to Private Link". Click "Open Private Link" to preview your JSON endpoint.
 


### PR DESCRIPTION
I originally made this branch to improve on the publishing docs, but I was beaten to it! :+1:

Anyway, I found a markdown link with too much escaping and fixed it. :)